### PR TITLE
Creating Tomato-specific CWSI Model

### DIFF
--- a/flask/app/views.py
+++ b/flask/app/views.py
@@ -299,13 +299,12 @@ class File(Resource):
 class Predict(Resource):
 	# Used to get a specific image details
 	def get(self, filename):
-
+		
 		files = dbfiles.find_one({"file_name": filename})
 		if files:
 			path = os.path.join(app.config['UPLOAD_FOLDER'],"Visual_Images_nocrop", filename)
 
 			if files['has_mask'] == False:
-
 				pred = Predictor(image=path, crop_type=files['crop_type'])
 				has_mask = pred.predictNsave()
 				
@@ -322,8 +321,10 @@ class Predict(Resource):
 				print("Crop width: ", crop_w)
 				print("Crop height: ", crop_h)
 				mean_sunlit_temp, leaves_np = crop_mask_and_overlay_temps(temps_np, mask_path, crop_w, crop_h, at, 7, 7)
-
-				CWSI = calculateCWSI(Ta=files['metadata']['AtmosphericTemperature'], Tc=mean_sunlit_temp, RH=files['metadata']['RelativeHumidity'])
+				CWSI = calculateCWSI(Ta=files['metadata']['AtmosphericTemperature'], 
+					Tc=mean_sunlit_temp, 
+					RH=files['metadata']['RelativeHumidity'],
+					crop_type = files['crop_type'])
 
 				# convert the numpy array of temperatures to binary so it can be stored in the mongodb
 				leaf_temps = Binary(pickle.dumps(leaves_np, protocol=2), subtype=128 )

--- a/flask/scripts/utility/utility.py
+++ b/flask/scripts/utility/utility.py
@@ -132,10 +132,12 @@ class NumpyEncoder(json.JSONEncoder):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
 
-def calculateCWSI(Ta,Tc,RH):
+def calculateCWSI(Ta,Tc,RH,crop_type):
     Slope = -1.49
     Intercept = 3.09
-
+    if crop_type == "Tomatoes":
+        Slope = -1.17
+        Intercept = 0.18
     # Ta = 30
     # Tc = 29
     # RH = 0.35

--- a/flask/scripts/utility/utility.py
+++ b/flask/scripts/utility/utility.py
@@ -138,6 +138,7 @@ def calculateCWSI(Ta,Tc,RH,crop_type):
     if crop_type == "Tomatoes":
         Slope = -1.17
         Intercept = 0.18
+
     # Ta = 30
     # Tc = 29
     # RH = 0.35
@@ -176,6 +177,9 @@ def calculateCWSI(Ta,Tc,RH,crop_type):
     print("VPG: ", VPG)
     print("T_ll: ", T_ll)
     print("T_ul: ", T_ul)
+    print("crop_type: ",crop_type)
+    print("Slope: ",Slope) 
+    print("Intercept: ",Intercept)
     print("CWSI: ", CWSI)
 
     return CWSI


### PR DESCRIPTION
- Using the slope and intercept found from the regression analysis of the tomato data on the Tc-Ta vs. VPD graph, I made it to where it is using this new slope and intercept rounded to 2 decimal places for calculating the CWSI if the crop_type is "Tomatoes", and uses the original slope and intercept in the code if the crop_type is anything else(Which is only Pistachios in our case).
![image](https://user-images.githubusercontent.com/54870618/236966142-a096874b-a010-4bec-a245-34bb39fc4d85.png)

- Added a printout of the crop_type, slope, and intercept to the console with the rest of the data for debugging purposes.
- Here is pictures of the console printouts that I got when running for Tomatoes and Pistachios:
Tomatoes: 
![image](https://user-images.githubusercontent.com/54870618/236966827-568c2b96-9f0e-48eb-ba4f-3866c334b525.png)
Pistachios:
![image](https://user-images.githubusercontent.com/54870618/236966704-42425353-b77f-4f4e-a080-9e9079ce92c1.png)

Let me know if there are any style changes I need to make!
